### PR TITLE
docs: schematic.svg在暗黑模式下filter invert

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -46,4 +46,15 @@ Promise.resolve(0)
 ```
 :::
 
-![schematic](./schematic.svg)
+<div class='schematic-img'>
+
+  <style> 
+  .schematic-img { filter: none; }
+  .dark .schematic-img { filter: invert(.9);}
+  </style>
+
+  ![schematic](./schematic.svg)
+  
+</div>
+
+


### PR DESCRIPTION

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/63382474/236405309-23957fa9-bff9-4b60-a4ed-0da3a63bf228.png">

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/63382474/236405254-94efeec1-49f2-405c-8b44-ed67018efb26.png">
在深色模式下schematic.svg 进行背景颜色反转，实现更好的可读性效果。